### PR TITLE
docs: Update comments in NgxLoadWithDirective

### DIFF
--- a/projects/ngx-load-with/src/lib/ngx-load-with.directive.ts
+++ b/projects/ngx-load-with/src/lib/ngx-load-with.directive.ts
@@ -74,7 +74,6 @@ export class NgxLoadWithDirective<T = unknown>
 
   /**
    * An optional template to be displayed while the data is being loaded.
-   * The template can access the `debouncing` property of the `LoadingTemplateContext` interface.
    */
   @Input('ngxLoadWithLoadingTemplate')
   loadingTemplate?: TemplateRef<unknown>;


### PR DESCRIPTION
Removed a reference to the non-existent 'debouncing' property from the comments associated with the loading template in NgxLoadWithDirective. This change ensures the comments accurately reflect the current implementation.