### PR TITLE
feat: add smarter reloading and re-rendering

### DIFF
--- a/projects/ngx-load-with/src/lib/ngx-load-with.directive.spec.ts
+++ b/projects/ngx-load-with/src/lib/ngx-load-with.directive.spec.ts
@@ -427,4 +427,34 @@ describe('NgxLoadWithDirective', () => {
     fixture.detectChanges();
     expect(getTextContent()).toEqual('plain');
   }));
+
+  it('should re-render the loading template when the loadingTemplate input changes', fakeAsync(() => {
+    component.loadWith = () => of('test').pipe(delay(1000));
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('loading');
+
+    // Update the loading template
+    component.showAlternativeTemplates = true;
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('loading alt');
+
+    tick(1000);
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('test');
+  }));
+
+  it('should re-render the error template when the errorTemplate input changes', fakeAsync(() => {
+    component.loadWith = () => throwError(() => new Error('An error occurred'));
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('An error occurred');
+
+    // Update the error template
+    component.showAlternativeTemplates = true;
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('error alt');
+  }));
 });

--- a/projects/ngx-load-with/src/lib/ngx-load-with.directive.spec.ts
+++ b/projects/ngx-load-with/src/lib/ngx-load-with.directive.spec.ts
@@ -28,8 +28,12 @@ import { NgxLoadWithDirective } from './ngx-load-with.directive';
       #loader="ngxLoadWith"
       [ngxLoadWith]="loadWith"
       [ngxLoadWithArgs]="args"
-      [ngxLoadWithLoadingTemplate]="loading"
-      [ngxLoadWithErrorTemplate]="error"
+      [ngxLoadWithLoadingTemplate]="
+        showAlternativeTemplates ? alternativeLoading : loading
+      "
+      [ngxLoadWithErrorTemplate]="
+        showAlternativeTemplates ? alternativeError : error
+      "
       [ngxLoadWithDebounceTime]="debounceTime"
       [ngxLoadWithStaleData]="staleData"
       let-data
@@ -41,6 +45,8 @@ import { NgxLoadWithDirective } from './ngx-load-with.directive';
     <ng-template #error let-error let-retry="retry">
       {{ error.message }} <button id="retry" (click)="retry()"></button>
     </ng-template>
+    <ng-template #alternativeLoading>loading alt</ng-template>
+    <ng-template #alternativeError>error alt</ng-template>
   `,
 })
 class TestComponent {
@@ -48,6 +54,7 @@ class TestComponent {
   debounceTime?: number;
   staleData?: boolean;
   args?: unknown;
+  showAlternativeTemplates = false;
 
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any,@typescript-eslint/no-unused-vars
   loadWith: any = (_args: any) => of('test' as any);
@@ -199,7 +206,21 @@ describe('NgxLoadWithDirective', () => {
     expect(getTextContent()).toEqual('test2');
   }));
 
-  it('should trigger a reload when args change', fakeAsync(() => {
+  it('should trigger a reload when ngxLoadWith changes', fakeAsync(() => {
+    component.loadWith = () => of('test1');
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('test1');
+
+    component.loadWith = () => of('test2');
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+    expect(getTextContent()).toEqual('test2');
+  }));
+
+  it('should trigger a reload when ngxLoadWithArgs changes', fakeAsync(() => {
     component.loadWith = (args: any) => of(args);
     component.args = 'test1';
     fixture.detectChanges();
@@ -211,8 +232,38 @@ describe('NgxLoadWithDirective', () => {
     fixture.detectChanges();
     tick();
     fixture.detectChanges();
-
     expect(getTextContent()).toEqual('test2');
+  }));
+
+  it('should not trigger a reload on input changes other than ngxLoadWith and ngxLoadWithArgs', fakeAsync(() => {
+    let loadWithCount = 0;
+
+    component.loadWith = (_args: any) => {
+      loadWithCount++;
+      return of('test');
+    };
+
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(getTextContent()).toEqual('test');
+    expect(loadWithCount).toEqual(1);
+
+    // Change inputs and expect no reload
+    component.staleData = true;
+    component.debounceTime = 1000;
+    // Change template inputs and expect no reload
+    component.showAlternativeTemplates = true;
+
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    expect(getTextContent()).toEqual('test');
+    expect(loadWithCount).toEqual(1);
+
+    discardPeriodicTasks();
   }));
 
   it('should handle multiple emissions', fakeAsync(() => {

--- a/projects/ngx-load-with/src/lib/ngx-load-with.directive.ts
+++ b/projects/ngx-load-with/src/lib/ngx-load-with.directive.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  SimpleChanges,
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
@@ -223,8 +224,10 @@ export class NgxLoadWithDirective<T = unknown>
     this.load();
   }
 
-  ngOnChanges(): void {
-    this.load();
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['ngxLoadWith'] || changes['args']) {
+      this.load();
+    }
   }
 
   ngOnDestroy(): void {

--- a/projects/ngx-load-with/src/lib/ngx-load-with.directive.ts
+++ b/projects/ngx-load-with/src/lib/ngx-load-with.directive.ts
@@ -193,6 +193,8 @@ export class NgxLoadWithDirective<T = unknown>
     loaded: false,
   };
 
+  private loadingStateSnapshot = this.initialLoadingState;
+
   private readonly loadingPhaseHandlers: loadingPhaseHandlers<T> = {
     loading: () => this.handleLoadingState(),
     loaded: (state) => this.handleLoadedState(state),
@@ -225,9 +227,9 @@ export class NgxLoadWithDirective<T = unknown>
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['ngxLoadWith'] || changes['args']) {
-      this.load();
-    }
+    this.handleReloadTriggeringChanges(changes);
+    this.handleTemplateChanges(changes, 'loadingTemplate', 'loading');
+    this.handleTemplateChanges(changes, 'errorTemplate', 'error');
   }
 
   ngOnDestroy(): void {
@@ -284,6 +286,7 @@ export class NgxLoadWithDirective<T = unknown>
   }
 
   private handleLoadingPhase(state: LoadingState<T>) {
+    this.loadingStateSnapshot = state;
     this.loadingStateChange.emit(state);
     const phase = this.getLoadingPhase(state);
     this.loadingPhaseHandlers[phase](state);
@@ -316,6 +319,10 @@ export class NgxLoadWithDirective<T = unknown>
     if (this.loadingViewRef) {
       return;
     }
+    this.renderLoadingTemplate();
+  }
+
+  private renderLoadingTemplate() {
     this.clearViewContainer();
     if (this.loadingTemplate) {
       this.loadingViewRef = this.viewContainer.createEmbeddedView(
@@ -344,6 +351,39 @@ export class NgxLoadWithDirective<T = unknown>
     this.viewContainer.clear();
     this.loadedViewRef = undefined;
     this.loadingViewRef = undefined;
+  }
+
+  // Input change management:
+
+  private handleTemplateChanges(
+    changes: SimpleChanges,
+    templateKey: 'loadingTemplate' | 'errorTemplate',
+    phase: LoadingPhase
+  ): void {
+    if (
+      changes[templateKey] &&
+      this.getLoadingPhase(this.loadingStateSnapshot) === phase
+    ) {
+      if (phase === 'loading') {
+        this.renderLoadingTemplate();
+      } else if (phase === 'error') {
+        this.handleErrorState(this.loadingStateSnapshot);
+      }
+    }
+  }
+
+  private handleReloadTriggeringChanges(changes: SimpleChanges) {
+    if (this.shouldTriggerReload(changes)) {
+      this.load();
+    }
+  }
+
+  private shouldTriggerReload(changes: SimpleChanges): boolean {
+    const reloadTriggeringKeys: (keyof NgxLoadWithDirective)[] = [
+      'ngxLoadWith',
+      'args',
+    ];
+    return reloadTriggeringKeys.some((key) => !!changes[key]);
   }
 
   // Load function management:


### PR DESCRIPTION
BREAKING CHANGE:

1. a reload is now only triggered when the `[ngxLoadWith]` (`*ngxLoadWith` in microsyntax) or the `[ngxLoadWithArgs]` (`args` in microsyntax) input changes. 
2. when changing the error or loading template while it's being shown, it will re-render with the new template. 